### PR TITLE
Fix POSTERUM label on homepage

### DIFF
--- a/dogma.html
+++ b/dogma.html
@@ -149,6 +149,23 @@
             color: #ddd;
             text-shadow: 0 0 5px rgba(0, 120, 255, 0.5);
         }
+
+        /* 하단 영역 스타일 */
+        .dogma-bottom {
+            position: fixed;
+            bottom: 20px;
+            left: 0;
+            width: 100%;
+            text-align: center;
+            z-index: 1000;
+        }
+        .dogma-bottom .btn {
+            margin: 0 20px;
+        }
+        .dogma-weird {
+            font-size: 24px;
+            margin: 0 10px;
+        }
     </style>
 </head>
 <body>
@@ -222,11 +239,18 @@
         <section id="page-content" class="section">
             <!-- 중앙에 크게 표시할 제목 -->
             <h1 class="center-title">DOGMA</h1>
-            
+
             <div class="content-area">
                 <!-- 여기는 내용을 비워둠 -->
             </div>
         </section>
+    </div>
+
+    <!-- 하단 중앙 문구 및 버튼 -->
+    <div class="dogma-bottom">
+        <a href="dogma-nature.html" class="btn btn-primary me-3">nature</a>
+        <span class="dogma-weird">T̴h̵u̴s̵ ̷S̷p̷o̸k̷e̶ ̴Z̶a̷r̵a̴t̶h̵u̶s̶t̷r̸a̴</span>
+        <a href="dogma-doctrine.html" class="btn btn-primary ms-3">doctrine</a>
     </div>
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
             padding-bottom: 50px;
         }
         
-        /* believe 비디오 섹션 스타일 (𝕻𝕺𝕾𝕿𝕰𝕽𝖀𝕸 글자 아래) */
+        /* believe 비디오 섹션 스타일 (ℙ𝕆𝕊𝕋𝔼ℝ𝕀𝕌𝕄 글자 아래) */
         .believe-video-section {
             width: 100%;
             max-width: 1200px;
@@ -228,7 +228,7 @@
         </video>
     </div>
     
-    <!-- 기존 하단 비디오 컨테이너는 제거하고 𝕻𝕺𝕾𝕿𝕰𝕽𝖀𝕸 글자 아래로 이동함 -->
+    <!-- 기존 하단 비디오 컨테이너는 제거하고 ℙ𝕆𝕊𝕋𝔼ℝ𝕀𝕌𝕄 글자 아래로 이동함 -->
 
     <!-- 상단 메뉴 -->
     <nav class="main-nav">
@@ -350,9 +350,9 @@ I think true love can happen in long distance relationship. But I dont want to s
             </div>
             
             <!-- 두 번째 제목 (ASCII 아트 아래로 이동) -->
-            <h2 class="second-title">𝕻𝕺𝕾𝕿𝕰𝕽𝖀𝕸</h2>
+            <h2 class="second-title">ℙ𝕆𝕊𝕋𝔼ℝ𝕀𝕌𝕄</h2>
             
-            <!-- believe 비디오를 여기로 이동 (𝕻𝕺𝕾𝕿𝕰𝕽𝖀𝕸 글자 아래) -->
+            <!-- believe 비디오를 여기로 이동 (ℙ𝕆𝕊𝕋𝔼ℝ𝕀𝕌𝕄 글자 아래) -->
             <div class="believe-video-section">
                 <div class="video-wrapper">
                     <video id="believe-video" loop muted autoplay playsinline preload="auto" onended="this.play()">


### PR DESCRIPTION
## Summary
- replace POSTERUM label with ℙ𝕆𝕊𝕋𝔼ℝ𝕀𝕌𝕄
- add footer with nature/doctrine links and glitch text on dogma page
- fix missing newline at end of HTML files

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845a949fa58832ca855fc07209510bb