### PR TITLE
Fix Nature page content loading

### DIFF
--- a/dogma-nature.html
+++ b/dogma-nature.html
@@ -160,6 +160,31 @@
         <source src="data/music.mp3" type="audio/mp3">
         번역: 브라우저가 오디오를 지원하지 않습니다.
     </audio>
-    <!-- 이하 본문 생략 -->
+
+    <div id="content">
+        <section id="page-content" class="section">
+            <h1 class="center-title">Nature</h1>
+            <div class="content-area markdown-content" id="markdown-content">
+                <!-- 내용이 로드됩니다 -->
+            </div>
+        </section>
+    </div>
+
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        fetch('data/nature.md')
+            .then(res => res.text())
+            .then(text => {
+                const html = text
+                    .trim()
+                    .split(/\n\s*\n/)
+                    .map(p => `<p>${p.replace(/\n/g, '<br>')}</p>`) 
+                    .join('\n');
+                document.getElementById('markdown-content').innerHTML = html;
+            })
+            .catch(err => console.error('Error loading markdown:', err));
+    </script>
+    <script src="audio-manager.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load text for the Nature page from `data/nature.md`
- show loaded text in a new content area on the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845b4dc38f0832cb302dab5da689559