### PR TITLE
Fix ASCII art images

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -19,9 +19,13 @@
 
 ### 웹사이트 실행 방법
 
-1. index.html 파일을 웹 브라우저(Chrome, Firefox, Edge 등)에서 열어주세요.
-2. 웹사이트가 열리면 ASCII Art 탭이 먼저 표시됩니다.
-3. "Matrix Rain 애니메이션" 탭을 클릭하여 푸른색 Matrix Rain 애니메이션을 볼 수 있습니다.
+1. 터미널에서 프로젝트 폴더로 이동한 뒤 간단한 웹 서버를 실행합니다.
+   예) Python이 설치되어 있다면 `python3 -m http.server` 명령을 사용합니다.
+2. 이렇게 실행한 서버 주소(`http://localhost:8000` 등)에서 `index.html`을 열어주세요.
+   파일을 직접 더블 클릭해 여는 경우 일부 브라우저에서 보안 정책 때문에
+   ASCII Art 텍스트가 로드되지 않을 수 있습니다.
+3. 웹사이트가 열리면 ASCII Art 탭이 먼저 표시됩니다.
+4. "Matrix Rain 애니메이션" 탭을 클릭하여 푸른색 Matrix Rain 애니메이션을 볼 수 있습니다.
 
 ### 참고사항
 

--- a/script.js
+++ b/script.js
@@ -279,6 +279,9 @@ $(document).ready(function() {
             generateRandomLetters();
         }).catch(error => {
             console.error('Error loading letters:', error);
+            const warn = '파일을 로드할 수 없습니다. 로컬 웹 서버에서 실행해 보세요.';
+            $('.art-1').text(warn);
+            $('.art-2').text(warn);
         });
     }
     // 랜덤 알파벳 생성 함수 (art-3용)

--- a/styles.css
+++ b/styles.css
@@ -41,7 +41,7 @@
 }
 
 .art-1 {
-  background-image: url('../data/image/image1.png');
+  background-image: url('data/image/image1.png');
   height: 600px;
   overflow: hidden; /* 스크롤 제거 */
   min-height: 500px;
@@ -53,7 +53,7 @@
 }
 
 .art-2 {
-  background-image: url('../data/image/image2.png');
+  background-image: url('data/image/image2.png');
   animation-delay: 5s;
   height: 600px;
   overflow: hidden; /* 스크롤 제거 */
@@ -66,7 +66,7 @@
 }
 
 .art-3 {
-  background-image: url('../data/image/image3.png');
+  background-image: url('data/image/image3.png');
   animation-delay: 10s;
   height: 600px;
   overflow: hidden; /* 스크롤 제거 */


### PR DESCRIPTION
## Summary
- use correct relative paths for background images used in ASCII art

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845b454cdb0832cb764f957b806da92